### PR TITLE
Add Select the First (or the Last) Elements action

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,11 +14,11 @@
             "command": "select-down"
         },
         {
-            "name": "Select First Elements",
+            "name": "Select the First",
             "command": "select-first"
         },
         {
-            "name": "Select Last Elements",
+            "name": "Select the Last",
             "command": "select-last"
         }
     ]

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,10 @@
         {
             "name": "Select First Elements",
             "command": "select-first"
+        },
+        {
+            "name": "Select Last Elements",
+            "command": "select-last"
         }
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,10 @@
         {
             "name": "Select Siblings Down",
             "command": "select-down"
+        },
+        {
+            "name": "Select First Elements",
+            "command": "select-first"
         }
     ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import selectUp from './select-up'
 import selectDown from './select-down'
 import selectFirst from './select-first'
+import selectLast from './select-last'
 
 if (figma.command == 'select-up') {
     selectUp()
@@ -14,5 +15,10 @@ if (figma.command == 'select-down') {
 
 if (figma.command == 'select-first') {
     selectFirst()
+    figma.closePlugin()
+}
+
+if (figma.command == 'select-last') {
+    selectLast()
     figma.closePlugin()
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import selectUp from './select-up'
 import selectDown from './select-down'
+import selectFirst from './select-first'
 
 if (figma.command == 'select-up') {
     selectUp()
@@ -8,5 +9,10 @@ if (figma.command == 'select-up') {
 
 if (figma.command == 'select-down') {
     selectDown()
+    figma.closePlugin()
+}
+
+if (figma.command == 'select-first') {
+    selectFirst()
     figma.closePlugin()
 }

--- a/src/select-first.ts
+++ b/src/select-first.ts
@@ -1,0 +1,36 @@
+import { getNodesParents, isDocumentNode } from './lib'
+
+/**
+ * Выделяет визуально первые элементы в контейнерах с авто-лейаутом
+ */
+export default function selectFirst() {
+    // Получаем набор выделенных элементов
+    let selection = figma.currentPage.selection
+
+    // Если не выбрано ни одного элемента, выходим
+    if (!selection.length) return
+
+    // Создаём заготовку для элементов, которые будет необходимо выделить
+    const elementsToSelect: SceneNode[] = []
+
+    // Собираем список родителей для выделенных элементов
+    const parents = getNodesParents(selection)
+
+    // Пробегаемся по списку родителей
+    for (const parent of parents) {
+
+        /*
+         Проверяем, не является родитель — целым документом (в этом случае его дети — страницы, их нельзя выделять). На практике такое невозможно, потому что родственники выделенного элемента не могут являться страницами (а их родитель, соответственно, — документом). Но иначе ругается TS-компилятор
+        */
+        if (isDocumentNode(parent)) continue
+
+        // Получаем первый элемент в списке (визуально он тоже будет первым, но в иерархии слоёв — последним)
+        const firstElement = parent.children[0]
+
+        // Добавляем его в список элементов для выделения
+        elementsToSelect.push(firstElement)
+    }
+
+    // Выделяем выбранные элементы
+    figma.currentPage.selection = elementsToSelect
+}

--- a/src/select-last.ts
+++ b/src/select-last.ts
@@ -1,0 +1,36 @@
+import { getNodesParents, isDocumentNode } from './lib'
+
+/**
+ * Выделяет визуально последние элементы в контейнерах с авто-лейаутом
+ */
+export default function selectLast() {
+    // Получаем набор выделенных элементов
+    let selection = figma.currentPage.selection
+
+    // Если не выбрано ни одного элемента, выходим
+    if (!selection.length) return
+
+    // Создаём заготовку для элементов, которые будет необходимо выделить
+    const elementsToSelect: SceneNode[] = []
+
+    // Собираем список родителей для выделенных элементов
+    const parents = getNodesParents(selection)
+
+    // Пробегаемся по списку родителей
+    for (const parent of parents) {
+
+        /*
+         Проверяем, не является родитель — целым документом (в этом случае его дети — страницы, их нельзя выделять). На практике такое невозможно, потому что родственники выделенного элемента не могут являться страницами (а их родитель, соответственно, — документом). Но иначе ругается TS-компилятор
+        */
+        if (isDocumentNode(parent)) continue
+
+        // Получаем последний элемент в списке (визуально он тоже будет последним, но в иерархии слоёв — первым)
+        const firstElement = parent.children.slice(-1)[0]
+
+        // Добавляем его в список элементов для выделения
+        elementsToSelect.push(firstElement)
+    }
+
+    // Выделяем выбранные элементы
+    figma.currentPage.selection = elementsToSelect
+}


### PR DESCRIPTION
Now the plugin allows to select siblings located at the top or at the bottom of the lists (i.e. located visually)